### PR TITLE
Add optimize CLI script

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -101,7 +101,18 @@ By default, it writes the output to `scrape.md`. Alternatively you can provide a
 `npm run query <question>` runs the codebase query agent at *src/swe/discovery/codebaseQuery.ts* which can answer ad hoc
 questions about a codebase/folder contents.
 
+### optimize
 
+`npm run optimize` runs the optimizeProjectStructure function configured in `src/cli/cli.ts`
+
+Without arguments, the script will optimize the project structure based on predefined rules. You can also provide specific options to customize the optimization process.
+
+For example, you could run:
+```bash
+npm run optimize -- --rules=custom-rules.json
+```
+
+This will use the custom rules defined in `custom-rules.json` to optimize the project structure.
 
 ## Development
 

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -3,6 +3,7 @@ import { unlinkSync } from 'node:fs';
 import { expect } from 'chai';
 import { systemDir } from '../appVars';
 import { parseUserCliArgs, saveAgentId } from './cli';
+import { optimizeProjectStructure } from '#swe/codeEditingAgent';
 
 describe('parseProcessArgs', () => {
 	beforeEach(() => {
@@ -38,5 +39,21 @@ describe('parseProcessArgs', () => {
 		const result = parseUserCliArgs('test', []);
 		expect(result.resumeAgentId).to.be.undefined;
 		expect(result.initialPrompt).to.be.empty;
+	});
+});
+
+describe('optimizeProjectStructure', () => {
+	it('should optimize project structure with default rules', async () => {
+		const result = await optimizeProjectStructure({});
+		expect(result).to.be.undefined;
+	});
+
+	it('should optimize project structure with custom rules', async () => {
+		const customRules = JSON.stringify([
+			{ type: 'move', from: 'src/old-folder', to: 'src/new-folder' },
+			{ type: 'delete', target: 'src/temp-file.ts' },
+		]);
+		const result = await optimizeProjectStructure({ rules: customRules });
+		expect(result).to.be.undefined;
 	});
 });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path, { join } from 'path';
 import { logger } from '#o11y/logger';
 import { systemDir } from '../appVars';
+import { optimizeProjectStructure } from '#swe/codeEditingAgent';
 
 export interface CliOptions {
 	/** Name of the executed .ts file without the extension */
@@ -68,3 +69,13 @@ export function getLastRunAgentId(scriptName: string): string | undefined {
 	logger.warn(`No agent to resume for ${scriptName} script`);
 	return undefined;
 }
+
+export async function main() {
+	const { initialPrompt } = parseProcessArgs();
+	await optimizeProjectStructure(initialPrompt);
+}
+
+main().then(
+	() => console.log('Optimization complete'),
+	(e) => console.error(e),
+);

--- a/src/swe/codeEditingAgent.ts
+++ b/src/swe/codeEditingAgent.ts
@@ -397,4 +397,53 @@ Then respond in following format:
 		const response: any = await llms().medium.generateJson(prompt, { id: 'extractFilenames' });
 		return response.files;
 	}
+
+	/**
+	 * Optimizes the project structure based on predefined rules or custom rules provided by the user.
+	 * @param options The options for optimizing the project structure, including custom rules if any.
+	 */
+	@func()
+	async optimizeProjectStructure(options: { rules?: string }): Promise<void> {
+		const fs: FileSystemService = getFileSystem();
+		const rules = options.rules ? JSON.parse(await fs.readFile(options.rules)) : this.getDefaultOptimizationRules();
+
+		for (const rule of rules) {
+			// Apply each optimization rule to the project structure
+			await this.applyOptimizationRule(rule);
+		}
+
+		logger.info('Project structure optimization complete.');
+	}
+
+	/**
+	 * Returns the default optimization rules for the project structure.
+	 */
+	private getDefaultOptimizationRules(): any[] {
+		return [
+			// Add default optimization rules here
+			{ type: 'move', from: 'src/old-folder', to: 'src/new-folder' },
+			{ type: 'delete', target: 'src/temp-file.ts' },
+			// Add more rules as needed
+		];
+	}
+
+	/**
+	 * Applies a single optimization rule to the project structure.
+	 * @param rule The optimization rule to apply.
+	 */
+	private async applyOptimizationRule(rule: any): Promise<void> {
+		const fs: FileSystemService = getFileSystem();
+
+		switch (rule.type) {
+			case 'move':
+				await fs.move(rule.from, rule.to);
+				break;
+			case 'delete':
+				await fs.delete(rule.target);
+				break;
+			// Add more rule types as needed
+			default:
+				logger.warn(`Unknown optimization rule type: ${rule.type}`);
+		}
+	}
 }


### PR DESCRIPTION
Add a new `optimize` CLI script and implement project structure optimization logic.

* **docs/docs/cli.md**
  - Add a new section for the `optimize` CLI script with usage examples and options.

* **src/cli/cli.ts**
  - Import `optimizeProjectStructure` function.
  - Implement the `optimize` CLI script to call the `optimizeProjectStructure` function.

* **src/swe/codeEditingAgent.ts**
  - Add a new method `optimizeProjectStructure` to handle the optimization logic.
  - Implement the optimization logic in the `optimizeProjectStructure` method.
  - Add helper methods `getDefaultOptimizationRules` and `applyOptimizationRule`.

* **src/cli/cli.test.ts**
  - Add tests for the new `optimize` CLI script.
  - Add tests for the `optimizeProjectStructure` function.

