### PR TITLE
refactor: remove frontend from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,5 +3,3 @@ dist
 bin
 .venv
 .typedai/
-frontend
-


### PR DESCRIPTION
After applying PR #45, the "frontend" directory is ignored during the local installation of the project (using `docker compose up --build`), causing an installation error.  
Removing this directory from `.dockerignore` allows the project to be installed locally without errors.

<img width="568" alt="Screenshot 2025-02-25 at 21 30 07" src="https://github.com/user-attachments/assets/7fbd6b95-f421-45d3-9045-444858707d19" />
